### PR TITLE
fix(bridge/ox): invalid group for grade check

### DIFF
--- a/framework/ox/client.lua
+++ b/framework/ox/client.lua
@@ -13,7 +13,9 @@ end
 function BRIDGE.GetPlayerJobGrade()
     local OxPlayer = Ox.GetPlayer()
     if not OxPlayer then return end
-    local JobGrade = OxPlayer.getGroup(OxPlayer.get('activeGroup'))
+    local activeGroup = OxPlayer.get('activeGroup')
+    if not activeGroup then return end
+    local JobGrade = OxPlayer.getGroup(activeGroup)
     if JobGrade then return JobGrade end
 end
 

--- a/framework/ox/server.lua
+++ b/framework/ox/server.lua
@@ -26,17 +26,6 @@ function BRIDGE.GetDob(src)
     end
 end
 
-local function isPlayerAllowed(src)
-    for k, v in pairs(Config.GiveCommand.AllowedGroup) do
-        if v == true then
-            if IsPlayerAceAllowed(src, k) then
-                return k
-            end
-        end
-    end
-    return "user"
-end
-
 function BRIDGE.GetPlayerJob(src)
     local OxPlayer = Ox.GetPlayer(src)
     if not OxPlayer then return end
@@ -47,7 +36,10 @@ function BRIDGE.GetPlayerJob(src)
 end
 
 function BRIDGE.GetGroup(src)
-    return isPlayerAllowed(src)
+    local OxPlayer = Ox.GetPlayer(src)
+    if not OxPlayer then return end
+    local Group = OxPlayer.get('activeGroup')
+    if Group then return Group end
 end
 
 return BRIDGE


### PR DESCRIPTION
## Description

Fixed an error that would happen when a player with no active group would attempt to create a document, where it would try to get the players grade in a null group. Cleaned up permission check in bridge.

### Fixes

  - Fixed invalid grade check.
  - Cleaned up permission check.